### PR TITLE
chore(maven-deps): optimize `junit-jupiter` dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,33 +11,19 @@
     <properties>
         <java.version>23</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.version>5.11.4</junit.version>
-        <assertj.version>3.27.0</assertj.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit.version}</version>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
+            <version>3.27.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## What changed?

Use `junit-jupiter` dependency which will aggregates `junit-jupiter-api`, `junit-jupiter-engine`, and `junit-jupiter-params`

## Checklist

- [x] I have performed a self-review of my own code
